### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "cpp"
+run = ""

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # Data Structures and Algorithms Implementations
 
 In this repo, I will add  implementation of data structures and algorithmic paradigms in different languages that i will learn over time. The goal is to make me familiar with how to implement common data structures and algorithms that is necessary for computer science students.
+
+[![Run on Repl.it](https://repl.it/badge/github/shishirjha/DataStructuresAndAlgorithmsImplementation)](https://repl.it/github/shishirjha/DataStructuresAndAlgorithmsImplementation)


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@ShishirJha/DataStructuresAndAlgorithmsImplementation).